### PR TITLE
Apply more uniform difficulty setting differences

### DIFF
--- a/scenarios/04_Islands.cfg
+++ b/scenarios/04_Islands.cfg
@@ -62,8 +62,8 @@
         controller=ai
         defeat_condition=no_units_left
         recruit=Merman Fighter, Merman Hunter, Mermaid Initiate
-        {GOLD 120 160 200}
-        {INCOME 4 6 8}
+        {GOLD 80 160 240}
+        {INCOME 3 6 9}
         team_name=merfolk
         user_team_name= _ "Merfolk"
         [leader]
@@ -84,8 +84,8 @@
         controller=ai
         defeat_condition=no_units_left
         recruit=Naga Fighter
-        {GOLD 100 140 180}
-        {INCOME 10 14 18}
+        {GOLD 70 140 210}
+        {INCOME 7 14 21}
         team_name=nagas
         user_team_name= _ "Nagas"
         [leader]
@@ -107,8 +107,8 @@
         controller=ai
         defeat_condition=no_units_left
         recruit=Merman Fighter, Merman Hunter, Mermaid Initiate
-        {GOLD 120 160 200}
-        {INCOME 10 14 18}
+        {GOLD 80 160 240}
+        {INCOME 7 14 21}
         team_name=merfolk
         user_team_name= _ "Merfolk"
         [leader]

--- a/scenarios/10_Fire_Meets_Steel.cfg
+++ b/scenarios/10_Fire_Meets_Steel.cfg
@@ -65,8 +65,8 @@
         side=2
         controller=ai
         recruit=Gryphon Rider, Gryphon Master
-        {GOLD 350 450 550}
-        {INCOME 15 22 30}
+        {GOLD 225 450 675}
+        {INCOME 11 22 33}
         team_name=dwarves
         user_team_name= _ "Dwarves"
         {FLAG_VARIANT knalgan}

--- a/scenarios/11_Confrontation.cfg
+++ b/scenarios/11_Confrontation.cfg
@@ -67,8 +67,8 @@
         side=2
         controller=ai
         recruit=Drake Arbiter, Drake Burner, Drake Clasher, Drake Fighter, Drake Flare, Drake Glider, Drake Thrasher, Drake Warrior, Fire Drake, Sky Drake
-        {GOLD 450 550 650}
-        {INCOME 15 20 25}
+        {GOLD 275 550 825}
+        {INCOME 10 20 30}
         team_name=rival
         user_team_name= _ "Drakes"
         {FLAG_VARIANT long}


### PR DESCRIPTION
Most scenarios use a 1:2:3 gold and income ratio for enemy forces to differentiate the easy, medium and hard difficulty settings (respectively). Apply this same ratio to scenarios 4, 10 and 11 (while keeping the middle difficulty the same)

Scenarios that balance difficulty settings through other means than gold and income are left unaffected